### PR TITLE
Update README to use python3 commands consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,13 @@ python3 myvault.py -f vault.json delete --property "*.old|temp.*"
 source venv/bin/activate
 
 # Run all tests
-python run_tests.py
+python3 run_tests.py
 
 # Run specific test modules
-python -m pytest tests/test_myvault.py -v
+python3 -m pytest tests/test_myvault.py -v
 
 # Run with coverage
-python -m pytest tests/ --cov=myvault --cov-report=html
+python3 -m pytest tests/ --cov=myvault --cov-report=html
 ```
 
 ### Test Structure


### PR DESCRIPTION
- Replace remaining 'python' commands with 'python3' in testing section
- Ensures explicit Python 3 usage across all documentation
- Improves cross-platform compatibility and follows modern best practices
- All commands now consistently use python3/pip3 for clarity

This completes the transition to explicit Python 3 command usage throughout the project documentation.