### PR TITLE
Standardize project naming to lowercase 'myvault'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# MyVault
+# myvault
 
 A comprehensive JSON-based Ansible Vault secret manager with property-based queries and secure CRUD operations.
 
 ## Overview
 
-MyVault is a sophisticated Python utility for managing Ansible Vault encrypted JSON files. It provides comprehensive CRUD operations for encrypted credential stores with property-based organization and secure password handling.
+myvault is a sophisticated Python utility for managing Ansible Vault encrypted JSON files. It provides comprehensive CRUD operations for encrypted credential stores with property-based organization and secure password handling.
 
 ## Features
 
@@ -79,7 +79,7 @@ deactivate
 
 ### Password Management
 
-MyVault supports flexible password input:
+myvault supports flexible password input:
 
 - **Environment variable** (recommended for automation):
 
@@ -118,7 +118,7 @@ python3 myvault.py [-f VAULT_FILE] [-d] {validate,read,create,update,delete} ...
 
 #### JSON Schema
 
-MyVault uses an extensible JSON schema where each entry requires a `property` field and supports arbitrary additional fields:
+myvault uses an extensible JSON schema where each entry requires a `property` field and supports arbitrary additional fields:
 
 ```json
 [
@@ -217,7 +217,9 @@ python3 myvault.py -f vault.json delete --property "*.old|temp.*"
 
 ### Pipeline and Scripting Usage
 
-MyVault outputs data in a pipe-separated format that's ideal for shell scripting and command pipelines.
+#### Output Format
+
+myvault outputs data in a pipe-separated format that's ideal for shell scripting and command pipelines.
 
 #### Output Format
 ```


### PR DESCRIPTION
## 📝 Documentation Update: Project Naming Standardization

This PR standardizes the project naming throughout the documentation to use lowercase 'myvault' consistently.

### Changes Made:
- ✅ **README.md**: Changed all instances of 'MyVault' to 'myvault'
- ✅ **Header**:  → 
- ✅ **Project description**: Consistent lowercase naming
- ✅ **Feature descriptions**: Updated references to use lowercase

### Rationale:
- **Follows standard conventions** for command-line tools and project names
- **Improves consistency** throughout documentation
- **Matches existing usage** in code examples and file names
- **Better alignment** with repository name and command usage

### Impact:
- 📖 **Documentation only** - no functional changes
- 🎯 **Improved consistency** across all project references
- 📚 **Better user experience** with unified naming

### Files Changed:
-  - 7 insertions(+), 5 deletions(-)

This is a minor documentation improvement that enhances the overall consistency and professionalism of the project documentation.