### PR TITLE
Enhance Quick Start with comprehensive vault password options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,21 @@ A comprehensive JSON-based Ansible Vault secret manager with property-based quer
    # Create JSON input file
    echo '[{"property": "website1.com", "username": "user@domain.com", "password": "secret123"}]' > secrets.json
    
-   # Create encrypted vault
+   # Create encrypted vault - choose ONE password option:
+   
+   # Option A: Set password via environment variable (recommended for scripts)
+   export VAULT_PASSWORD="your_secure_vault_password"
    python3 myvault.py -f vault.json create -i secrets.json
+   
+   # Option B: Interactive prompt (recommended for manual use)
+   python3 myvault.py -f vault.json create -i secrets.json
+   # Will prompt: "Enter Ansible Vault password: "
+   
+   # Option C: Let environment.sh help set it up (from Step 1)
+   # The environment script can optionally configure vault password for the session
    ```
+
+   **Password Priority**: Options are mutually exclusive - myvault uses environment variable if set, otherwise prompts interactively.
 
 3. **Read from vault**:
    ```bash


### PR DESCRIPTION
## Summary

Improves the Quick Start Step 2 by adding comprehensive vault password setup guidance.

## Changes Made

### Enhanced Step 2: Create your first vault

Added three password setup options with clear explanations:

- **Option A**: Environment variable (recommended for scripts)
  ```bash
  export VAULT_PASSWORD="your_secure_vault_password"
  ```

- **Option B**: Interactive prompt (recommended for manual use)
  - Will prompt: "Enter Ansible Vault password: "

- **Option C**: Environment script setup (from Step 1)
  - The environment.sh script can optionally configure vault password

### Added Mutual Exclusivity Explanation

**Password Priority**: Options are mutually exclusive - myvault uses environment variable if set, otherwise prompts interactively.

## Benefits

- ✅ **Complete guidance**: Users understand all password options before creating their first vault
- ✅ **Clear priority**: Explains exactly how myvault chooses between options  
- ✅ **Use case recommendations**: Suggests best option for different scenarios
- ✅ **No surprises**: Users know they'll be prompted if no environment variable is set

## Technical Details

Based on code analysis of myvault.py lines 314-330:
1. Environment variable `VAULT_PASSWORD` takes precedence
2. Interactive prompt via `getpass` as fallback
3. Options are mutually exclusive by design

## Breaking Changes

None - this only enhances documentation clarity.