### PR TITLE
feat: add auto-tag and release workflow on myvault.py changes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,40 @@
+name: Auto Tag & Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - myvault.py
+
+jobs:
+  tag:
+    name: Bump version and create release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Only create a tag for feat/fix/BREAKING CHANGE commits.
+          # chore, docs, test, ci commits do not produce a new tag.
+          default_bump: false
+          release_branches: main
+          tag_prefix: v
+
+      - name: Create GitHub Release
+        if: steps.tag.outputs.new_tag != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.new_tag }}
+          name: ${{ steps.tag.outputs.new_tag }}
+          body: ${{ steps.tag.outputs.changelog }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - myvault.py
 
+concurrency:
+  group: auto-tag-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   tag:
     name: Bump version and create release


### PR DESCRIPTION
Adds `.github/workflows/auto-tag.yml`, a workflow that automatically creates a semver tag and GitHub Release whenever `myvault.py` changes land on `main`.

## How it works

- **Trigger:** `push` to `main` filtered to `paths: myvault.py` — only fires when the main script is modified.
- **Versioning:** driven by conventional commit prefixes on the merge commit:
  - `feat:` → minor bump (e.g. `v1.0.0 → v1.1.0`)
  - `fix:` → patch bump (e.g. `v1.0.0 → v1.0.1`)
  - `feat!:` / `BREAKING CHANGE` footer → major bump
  - `chore:`, `docs:`, `test:`, `ci:` → no tag (default_bump: false)
- **Output:** an annotated `vX.Y.Z` tag on `main` + a GitHub Release with auto-generated changelog.
- **Permissions:** uses the built-in `GITHUB_TOKEN` with `contents: write` only — no additional secrets required.

## Changes

- `.github/workflows/auto-tag.yml` — new workflow using `mathieudutour/github-tag-action@v6.2` and `softprops/action-gh-release@v2`

## Security considerations

- No secrets, passwords, or vault data are involved.
- `GITHUB_TOKEN` permissions are scoped to `contents: write` only.
- No new code paths in `myvault.py`.

## Testing

- Workflow only runs on merge to `main` when `myvault.py` is in the diff; no existing tests are affected.

## Breaking changes

None.
