### PR TITLE
chore: upgrade CodeQL actions from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"


### PR DESCRIPTION
Upgrades `github/codeql-action/init` and `github/codeql-action/analyze` from `@v3` to `@v4` in `.github/workflows/codeql.yml`. CodeQL Action v3 will be deprecated in December 2026; without this change the security scan job would fail on every push and PR after that date.
