### PR TITLE
fix: tolerate non-zero editor exit when file was modified

### DIFF
--- a/myvault.py
+++ b/myvault.py
@@ -917,11 +917,21 @@ def handle_edit(args, vault_password: str) -> None:
                     # Some editor plugins (linters, formatters) exit with a non-zero
                     # code even after successfully writing the file.  Check whether
                     # the file was actually modified before deciding to abort.
+                    # Read as bytes so non-UTF-8 content from the editor never raises
+                    # UnicodeDecodeError here; the hash comparison is encoding-agnostic.
                     try:
-                        with open(tmp_path, 'r', encoding='utf-8') as f:
-                            post_content = f.read()
-                        post_hash = hashlib.sha256(post_content.encode('utf-8')).hexdigest()
+                        with open(tmp_path, 'rb') as f:
+                            post_bytes = f.read()
+                        post_hash = hashlib.sha256(post_bytes).hexdigest()
                         file_changed = post_hash != pre_hash
+                        # Decode for downstream JSON validation; keep post_content as
+                        # str so the validation block can reuse it without a second read.
+                        # A UnicodeDecodeError here means invalid UTF-8 — that will be
+                        # caught as a JSONDecodeError in the validation step.
+                        try:
+                            post_content = post_bytes.decode('utf-8')
+                        except UnicodeDecodeError:
+                            post_content = None
                     except OSError as e:
                         logger.warning(
                             f"Editor exited with non-zero code: {exit_code}, "

--- a/myvault.py
+++ b/myvault.py
@@ -899,11 +899,15 @@ def handle_edit(args, vault_password: str) -> None:
             print(f"Opening vault in {editor}... (save and quit to apply changes, quit without saving to cancel)")
 
             while True:
-                # Capture a baseline immediately before each editor invocation so
-                # that change-detection reflects *this* session's edits, not the
-                # state from a prior iteration (e.g. after a JSON-validation retry).
-                with open(tmp_path, 'r', encoding='utf-8') as f:
-                    original_content = f.read()
+                # Take a cheap stat-based snapshot (size + mtime_ns) immediately
+                # before each editor invocation.  Full content is only read on the
+                # normal validation path below; this avoids an extra full-file read
+                # on every successful (exit 0) iteration.
+                try:
+                    pre_stat = os.stat(tmp_path)
+                    pre_key = (pre_stat.st_size, pre_stat.st_mtime_ns)
+                except OSError:
+                    pre_key = None
 
                 # Open editor and wait for it to exit
                 exit_code = subprocess.call([editor, tmp_path])
@@ -912,13 +916,16 @@ def handle_edit(args, vault_password: str) -> None:
                     # Some editor plugins (linters, formatters) exit with a non-zero
                     # code even after successfully writing the file.  Check whether
                     # the file was actually modified before deciding to abort.
-                    try:
-                        with open(tmp_path, 'r', encoding='utf-8') as f:
-                            current_content = f.read()
-                    except OSError:
-                        current_content = original_content
+                    file_changed = False
+                    if pre_key is not None:
+                        try:
+                            post_stat = os.stat(tmp_path)
+                            post_key = (post_stat.st_size, post_stat.st_mtime_ns)
+                            file_changed = post_key != pre_key
+                        except OSError:
+                            pass
 
-                    if current_content == original_content:
+                    if not file_changed:
                         logger.warning(f"Editor exited with non-zero code: {exit_code}, file unmodified — aborting")
                         print(f"Editor exited with code {exit_code}. Changes not saved.", file=sys.stderr)
                         return

--- a/myvault.py
+++ b/myvault.py
@@ -896,19 +896,18 @@ def handle_edit(args, vault_password: str) -> None:
                 tmp_file.write("\n")
             tmp_fd = None  # fd is now closed via fdopen
 
+            # Compute a content hash of the bytes written to the temp file.  This
+            # serves as the per-iteration baseline for change detection without
+            # requiring an extra file read on the normal (exit 0) path.
+            initial_bytes = (
+                json.dumps(vault_data, indent=2, ensure_ascii=False) + "\n"
+            ).encode('utf-8')
+            pre_hash = hashlib.sha256(initial_bytes).hexdigest()
+            del initial_bytes
+
             print(f"Opening vault in {editor}... (save and quit to apply changes, quit without saving to cancel)")
 
             while True:
-                # Take a cheap stat-based snapshot (size + mtime_ns) immediately
-                # before each editor invocation.  Full content is only read on the
-                # normal validation path below; this avoids an extra full-file read
-                # on every successful (exit 0) iteration.
-                try:
-                    pre_stat = os.stat(tmp_path)
-                    pre_key = (pre_stat.st_size, pre_stat.st_mtime_ns)
-                except OSError:
-                    pre_key = None
-
                 # Open editor and wait for it to exit
                 exit_code = subprocess.call([editor, tmp_path])
 
@@ -916,14 +915,13 @@ def handle_edit(args, vault_password: str) -> None:
                     # Some editor plugins (linters, formatters) exit with a non-zero
                     # code even after successfully writing the file.  Check whether
                     # the file was actually modified before deciding to abort.
-                    file_changed = False
-                    if pre_key is not None:
-                        try:
-                            post_stat = os.stat(tmp_path)
-                            post_key = (post_stat.st_size, post_stat.st_mtime_ns)
-                            file_changed = post_key != pre_key
-                        except OSError:
-                            pass
+                    try:
+                        with open(tmp_path, 'r', encoding='utf-8') as f:
+                            post_content = f.read()
+                        post_hash = hashlib.sha256(post_content.encode('utf-8')).hexdigest()
+                        file_changed = post_hash != pre_hash
+                    except OSError:
+                        file_changed = False
 
                     if not file_changed:
                         logger.warning(f"Editor exited with non-zero code: {exit_code}, file unmodified — aborting")
@@ -948,6 +946,9 @@ def handle_edit(args, vault_password: str) -> None:
                     print(f"\nError: {e}", file=sys.stderr)
                     response = input("Invalid JSON. Re-open editor to fix? (y/N): ").strip().lower()
                     if response in ('y', 'yes'):
+                        # Update the baseline so the next iteration compares against
+                        # what the editor last wrote, not the original vault content.
+                        pre_hash = hashlib.sha256(edited_content.encode('utf-8')).hexdigest()
                         continue
                     else:
                         print("Edit cancelled. No changes saved.")

--- a/myvault.py
+++ b/myvault.py
@@ -896,13 +896,15 @@ def handle_edit(args, vault_password: str) -> None:
                 tmp_file.write("\n")
             tmp_fd = None  # fd is now closed via fdopen
 
-            # Capture original content as a baseline for change detection
-            with open(tmp_path, 'r', encoding='utf-8') as f:
-                original_content = f.read()
-
             print(f"Opening vault in {editor}... (save and quit to apply changes, quit without saving to cancel)")
 
             while True:
+                # Capture a baseline immediately before each editor invocation so
+                # that change-detection reflects *this* session's edits, not the
+                # state from a prior iteration (e.g. after a JSON-validation retry).
+                with open(tmp_path, 'r', encoding='utf-8') as f:
+                    original_content = f.read()
+
                 # Open editor and wait for it to exit
                 exit_code = subprocess.call([editor, tmp_path])
 

--- a/myvault.py
+++ b/myvault.py
@@ -896,6 +896,10 @@ def handle_edit(args, vault_password: str) -> None:
                 tmp_file.write("\n")
             tmp_fd = None  # fd is now closed via fdopen
 
+            # Capture original content as a baseline for change detection
+            with open(tmp_path, 'r', encoding='utf-8') as f:
+                original_content = f.read()
+
             print(f"Opening vault in {editor}... (save and quit to apply changes, quit without saving to cancel)")
 
             while True:
@@ -903,9 +907,24 @@ def handle_edit(args, vault_password: str) -> None:
                 exit_code = subprocess.call([editor, tmp_path])
 
                 if exit_code != 0:
-                    logger.warning(f"Editor exited with non-zero code: {exit_code}")
-                    print(f"Editor exited with code {exit_code}. Changes not saved.", file=sys.stderr)
-                    return
+                    # Some editor plugins (linters, formatters) exit with a non-zero
+                    # code even after successfully writing the file.  Check whether
+                    # the file was actually modified before deciding to abort.
+                    try:
+                        with open(tmp_path, 'r', encoding='utf-8') as f:
+                            current_content = f.read()
+                    except OSError:
+                        current_content = original_content
+
+                    if current_content == original_content:
+                        logger.warning(f"Editor exited with non-zero code: {exit_code}, file unmodified — aborting")
+                        print(f"Editor exited with code {exit_code}. Changes not saved.", file=sys.stderr)
+                        return
+
+                    logger.warning(
+                        f"Editor exited with non-zero code: {exit_code}, "
+                        "but file was modified — proceeding with validation"
+                    )
 
                 # Read back and validate JSON
                 try:

--- a/myvault.py
+++ b/myvault.py
@@ -956,20 +956,26 @@ def handle_edit(args, vault_password: str) -> None:
                         edited_content = post_content
                         post_content = None
                     else:
-                        with open(tmp_path, 'r', encoding='utf-8') as f:
-                            edited_content = f.read()
+                        with open(tmp_path, 'rb') as f:
+                            edited_content = f.read().decode('utf-8')
 
                     edited_data = json.loads(edited_content)
                     validated_data = JSONValidator.validate_json_structure(edited_data)
                     break  # Valid JSON — proceed
 
-                except (json.JSONDecodeError, VaultError) as e:
+                except (json.JSONDecodeError, UnicodeDecodeError, VaultError) as e:
                     print(f"\nError: {e}", file=sys.stderr)
                     response = input("Invalid JSON. Re-open editor to fix? (y/N): ").strip().lower()
                     if response in ('y', 'yes'):
                         # Update the baseline so the next iteration compares against
                         # what the editor last wrote, not the original vault content.
-                        pre_hash = hashlib.sha256(edited_content.encode('utf-8')).hexdigest()
+                        # If edited_content is not set (e.g. UnicodeDecodeError before
+                        # assignment), re-hash from disk bytes so the baseline is correct.
+                        try:
+                            with open(tmp_path, 'rb') as f:
+                                pre_hash = hashlib.sha256(f.read()).hexdigest()
+                        except OSError:
+                            pass
                         continue
                     else:
                         print("Edit cancelled. No changes saved.")

--- a/myvault.py
+++ b/myvault.py
@@ -891,17 +891,17 @@ def handle_edit(args, vault_password: str) -> None:
         tmp_fd, tmp_path = tempfile.mkstemp(suffix=".json", prefix="myvault_edit_", dir=tmpdir)
         try:
             os.chmod(tmp_path, 0o600)
-            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as tmp_file:
-                json.dump(vault_data, tmp_file, indent=2, ensure_ascii=False)
-                tmp_file.write("\n")
-            tmp_fd = None  # fd is now closed via fdopen
-
-            # Compute a content hash of the bytes written to the temp file.  This
-            # serves as the per-iteration baseline for change detection without
-            # requiring an extra file read on the normal (exit 0) path.
+            # Write in binary mode with explicit LF termination so the on-disk bytes
+            # are identical to what we hash for change detection (no CRLF translation).
             initial_bytes = (
                 json.dumps(vault_data, indent=2, ensure_ascii=False) + "\n"
             ).encode('utf-8')
+            with os.fdopen(tmp_fd, 'wb') as tmp_file:
+                tmp_file.write(initial_bytes)
+            tmp_fd = None  # fd is now closed via fdopen
+
+            # Derive the baseline hash from the bytes actually written to disk so
+            # the comparison is always accurate regardless of platform newline handling.
             pre_hash = hashlib.sha256(initial_bytes).hexdigest()
             del initial_bytes
 

--- a/myvault.py
+++ b/myvault.py
@@ -908,6 +908,8 @@ def handle_edit(args, vault_password: str) -> None:
             print(f"Opening vault in {editor}... (save and quit to apply changes, quit without saving to cancel)")
 
             while True:
+                post_content = None  # set on non-zero exit path; reused below to avoid duplicate read
+
                 # Open editor and wait for it to exit
                 exit_code = subprocess.call([editor, tmp_path])
 
@@ -920,7 +922,11 @@ def handle_edit(args, vault_password: str) -> None:
                             post_content = f.read()
                         post_hash = hashlib.sha256(post_content.encode('utf-8')).hexdigest()
                         file_changed = post_hash != pre_hash
-                    except OSError:
+                    except OSError as e:
+                        logger.warning(
+                            f"Editor exited with non-zero code: {exit_code}, "
+                            f"change detection failed ({type(e).__name__}) — aborting"
+                        )
                         file_changed = False
 
                     if not file_changed:
@@ -933,10 +939,15 @@ def handle_edit(args, vault_password: str) -> None:
                         "but file was modified — proceeding with validation"
                     )
 
-                # Read back and validate JSON
+                # Read back and validate JSON.  Reuse post_content when already read
+                # on the non-zero exit path to avoid a redundant file read.
                 try:
-                    with open(tmp_path, 'r', encoding='utf-8') as f:
-                        edited_content = f.read()
+                    if post_content is not None:
+                        edited_content = post_content
+                        post_content = None
+                    else:
+                        with open(tmp_path, 'r', encoding='utf-8') as f:
+                            edited_content = f.read()
 
                     edited_data = json.loads(edited_content)
                     validated_data = JSONValidator.validate_json_structure(edited_data)

--- a/tests/test_myvault.py
+++ b/tests/test_myvault.py
@@ -1188,7 +1188,7 @@ class TestEditCommand:
         modified_data = self.SAMPLE_VAULT_DATA + [new_entry]
 
         def editor_writes_and_exits_nonzero(cmd):
-            with open(cmd[1], 'w') as f:
+            with open(cmd[1], 'w', encoding='utf-8', newline='\n') as f:
                 json.dump(modified_data, f, indent=2)
             return 1  # simulates a vim plugin exiting non-zero after a clean write
 

--- a/tests/test_myvault.py
+++ b/tests/test_myvault.py
@@ -1167,6 +1167,41 @@ class TestEditCommand:
 
     @patch('myvault.VaultManager')
     @patch('myvault.JSONValidator.validate_file_permissions')
+    @patch('tempfile.mkstemp')
+    def test_handle_edit_editor_nonzero_exit_but_file_modified(
+            self, mock_mkstemp, mock_validate, mock_vault_class, tmp_path, capsys):
+        """Test that a non-zero exit code is tolerated when the editor modified the file.
+
+        Reproduces the case where a vim plugin (e.g. ALE) exits with code 1 after a
+        successful :wq on a file that contains a blank field, causing the edit to be
+        discarded even though the user intended to save.
+        """
+        tmp_file = tmp_path / "myvault_edit_test.json"
+        tmp_file.write_text(json.dumps(self.SAMPLE_VAULT_DATA))
+        mock_mkstemp.return_value = (os.open(str(tmp_file), os.O_RDWR), str(tmp_file))
+
+        mock_vault = MagicMock()
+        mock_vault.load_vault_file.return_value = self.SAMPLE_VAULT_DATA
+        mock_vault_class.return_value = mock_vault
+
+        new_entry = {"property": "newsite.com", "username": "newuser", "password": "newpass"}
+        modified_data = self.SAMPLE_VAULT_DATA + [new_entry]
+
+        def editor_writes_and_exits_nonzero(cmd):
+            with open(cmd[1], 'w') as f:
+                json.dump(modified_data, f, indent=2)
+            return 1  # simulates a vim plugin exiting non-zero after a clean write
+
+        args = self._make_args(editor="vi")
+        with patch('subprocess.call', side_effect=editor_writes_and_exits_nonzero):
+            myvault.handle_edit(args, "password")
+
+        mock_vault.save_vault_file.assert_called_once()
+        captured = capsys.readouterr()
+        assert "saved successfully" in captured.out
+
+    @patch('myvault.VaultManager')
+    @patch('myvault.JSONValidator.validate_file_permissions')
     @patch('builtins.input', return_value='n')
     @patch('tempfile.mkstemp')
     def test_handle_edit_invalid_json_cancel(self, mock_mkstemp, mock_input, mock_validate,


### PR DESCRIPTION
## Summary
Editor plugins (e.g. ALE, LSP linters in vim/neovim) can exit with a non-zero status code even after a successful `:wq` when the file contains a blank field. Previously, `handle_edit` treated any non-zero exit as a user-initiated cancel and discarded the changes.

## Changes
- `myvault.py`: Capture a baseline of the temp file's content before launching the editor. On a non-zero exit, compare current content to the baseline. Only abort if the file is unchanged; otherwise log a warning and continue with validation.
- `tests/test_myvault.py`: Add `test_handle_edit_editor_nonzero_exit_but_file_modified` — verifies that a non-zero editor exit is tolerated when the file was modified, and that `save_vault_file` is still called.

## Motivation
Reproduces a real-world annoyance: editing a vault entry with a blank `username` field in vim with the ALE plugin active causes the edit to be silently discarded on `:wq` because ALE exits with code 1 after running linters. The user has no indication the save was ignored.

## Security considerations
- No changes to how vault data is encrypted or decrypted.
- The extra file read (for baseline capture) operates on the same RAM-disk temp file already used by `handle_edit` and is processed entirely in memory — nothing written to disk.
- `bandit` clean.

## Testing
- `python -m pytest tests/ -v` — 88 passed, 0 failed
- New test covers the non-zero exit + modified file path explicitly.

## Breaking changes
None.
