### PR TITLE
fix: auto-discover newest suitable Python for venv creation

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -41,8 +41,10 @@ find_suitable_python() {
 }
 
 # Check if virtual environment exists, creating it with the best available Python
-PYTHON_BIN="$(find_suitable_python)" || return 1
-[ -d "$PROJECT_ROOT/venv" ] || "$PYTHON_BIN" -m venv "$PROJECT_ROOT/venv"
+if [ ! -d "$PROJECT_ROOT/venv" ]; then
+    PYTHON_BIN="$(find_suitable_python)" || return 1
+    "$PYTHON_BIN" -m venv "$PROJECT_ROOT/venv" || return 1
+fi
 
 # Deactivate any existing virtual environment
 if [ -n "$VIRTUAL_ENV" ]; then

--- a/environment.sh
+++ b/environment.sh
@@ -36,7 +36,7 @@ find_suitable_python() {
         return 0
     fi
 
-    echo "Error: Python >= $MIN_PYTHON_VERSION not found. Install via: brew install python@3.13" >&2
+    echo "Error: Python >= $MIN_PYTHON_VERSION not found. Install Python >= $MIN_PYTHON_VERSION and ensure it is available on PATH." >&2
     return 1
 }
 

--- a/environment.sh
+++ b/environment.sh
@@ -11,8 +11,38 @@ PROJECT_ROOT="$SCRIPT_DIR"
 
 echo "Setting up MyVault development environment..."
 
-# Check if virtual environment exists
-[ -d "$PROJECT_ROOT/venv" ] || python3 -m venv venv
+# Minimum Python version required (update only when project requirements change)
+MIN_PYTHON_VERSION="3.12"
+
+# Find the newest installed Python that meets the minimum version requirement.
+# Scans python3.X (X = 30..MIN_MINOR) so new releases are picked up automatically.
+find_suitable_python() {
+    local min_major min_minor
+    min_major=$(echo "$MIN_PYTHON_VERSION" | cut -d. -f1)
+    min_minor=$(echo "$MIN_PYTHON_VERSION" | cut -d. -f2)
+
+    for minor in $(seq 30 -1 "$min_minor"); do
+        local candidate="${min_major}.${minor}"
+        if command -v "python${candidate}" &>/dev/null; then
+            echo "python${candidate}"
+            return 0
+        fi
+    done
+
+    # Fall back to generic python3 if it satisfies the minimum
+    if command -v python3 &>/dev/null && \
+       python3 -c "import sys; sys.exit(0 if sys.version_info >= ($min_major, $min_minor) else 1)" 2>/dev/null; then
+        echo "python3"
+        return 0
+    fi
+
+    echo "Error: Python >= $MIN_PYTHON_VERSION not found. Install via: brew install python@3.13" >&2
+    return 1
+}
+
+# Check if virtual environment exists, creating it with the best available Python
+PYTHON_BIN="$(find_suitable_python)" || return 1
+[ -d "$PROJECT_ROOT/venv" ] || "$PYTHON_BIN" -m venv venv
 
 # Deactivate any existing virtual environment
 if [ -n "$VIRTUAL_ENV" ]; then

--- a/environment.sh
+++ b/environment.sh
@@ -42,7 +42,7 @@ find_suitable_python() {
 
 # Check if virtual environment exists, creating it with the best available Python
 PYTHON_BIN="$(find_suitable_python)" || return 1
-[ -d "$PROJECT_ROOT/venv" ] || "$PYTHON_BIN" -m venv venv
+[ -d "$PROJECT_ROOT/venv" ] || "$PYTHON_BIN" -m venv "$PROJECT_ROOT/venv"
 
 # Deactivate any existing virtual environment
 if [ -n "$VIRTUAL_ENV" ]; then


### PR DESCRIPTION
Replace the hardcoded `python3` call in `environment.sh` with a `find_suitable_python()` function that automatically discovers the newest installed Python meeting the project's minimum version requirement.

**Problem:** `environment.sh` called bare `python3` to create the venv, which on macOS resolves to the system Python at `/usr/bin/python3` (3.9.6) before any Homebrew Python in PATH. This caused `pip install` to fail since `ansible>=13.6.0` requires Python >=3.12.

**Fix:** A `find_suitable_python()` function scans `python3.30` down to `python3.12`, returning the first binary found. This means any newly installed Homebrew Python is picked up automatically without script changes. A `MIN_PYTHON_VERSION` constant at the top of the script is the single place to update if the project's minimum Python requirement ever changes.

Closes #N/A
