### PR TITLE
chore: adapt review.prompt.md for MyVault docs and instructions

### DIFF
--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -36,18 +36,18 @@ Follow these steps exactly.
   - Rejected: claim is factually wrong, contradicts current code or documented project decisions, OR is technically accurate but does not prevent a realistic operator failure (e.g. wording preferences, hypothetical edge cases in manually-executed runbooks, style inconsistencies, defensive improvements without a demonstrated failure path).
   - Ambiguous: cannot be resolved from available evidence; pause and ask user.
 
-For docs-only PRs, additionally reject:
-  - Observations about prose style or word choice where the current wording is unambiguous in context
-  - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
-  - Suggestions that duplicate information already present elsewhere in the same document
+  For docs-only PRs, additionally reject:
+    - Observations about prose style or word choice where the current wording is unambiguous in context
+    - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
+    - Suggestions that duplicate information already present elsewhere in the same document
 
-  - Apply focused fixes.
-  - Verify each change in files.
-  - Commit per batch with clear message.
-  - Reply to each comment with concise factual status.
-  - Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
-    — the PR number is REQUIRED before `comments`; omitting it returns 404.
-    — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
+    - Apply focused fixes.
+    - Verify each change in files.
+    - Commit per batch with clear message.
+    - Reply to each comment with concise factual status.
+    - Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
+      — the PR number is REQUIRED before `comments`; omitting it returns 404.
+      — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
 
 6. Keep docs in sync.
   - If fixes alter contracts, schema, workflow, or security behavior, update docs in same pass.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -3,24 +3,28 @@ agent: agent
 description: Review all PR comments for this repository, validate each claim against project docs and changed files, fix valid issues, and post concise replies. Use MyVault's documentation and instruction files as authoritative sources.
 ---
 
+
 Follow these steps exactly.
 
-1. Identify PR context.
-- Run gh pr view --json number,headRefName.
-- If there is no open PR for the current branch, stop and report that state.
 
-- List changed files from the PR.
-- Read each changed file in full.
-- Read relevant docs from this repository:
-  - docs/API.md
-  - docs/DEVELOPMENT.md
-  - docs/EXAMPLES.md
-  - docs/INSTALLATION.md
-  - docs/WORKFLOW.md
-- Read relevant instruction files from .github/instructions based on touched files:
-  - .github/instructions/pr.instructions.md
-  - .github/instructions/security.instructions.md
-  - .github/instructions/test.instructions.md
+1. Identify PR context.
+   - Run gh pr view --json number,headRefName.
+   - If there is no open PR for the current branch, stop and report that state.
+
+2. Gather authoritative context for this project.
+   - List changed files from the PR.
+   - Read each changed file in full.
+   - Read relevant docs from this repository:
+     - docs/API.md
+     - docs/DEVELOPMENT.md
+     - docs/EXAMPLES.md
+     - docs/INSTALLATION.md
+     - docs/WORKFLOW.md
+   - Read relevant instruction files from .github/instructions based on touched files:
+     - .github/instructions/pr.instructions.md
+     - .github/instructions/security.instructions.md
+     - .github/instructions/test.instructions.md
+     - .github/instructions/docs.instructions.md (if any docs/** files are changed)
 
 3. Fetch all review comments.
 - Top-level PR comments: gh pr view <number> --comments
@@ -37,30 +41,27 @@ For docs-only PRs, additionally reject:
   - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
   - Suggestions that duplicate information already present elsewhere in the same document
 
-5. Process valid comments in small batches.
-- Apply focused fixes.
-- Verify each change in files.
-- Commit per batch with clear message.
-- If detect-secrets updates .secrets.baseline metadata, stage it and retry commit.
-- Reply to each comment with concise factual status.
-- Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
-  — the PR number is REQUIRED before `comments`; omitting it returns 404.
-  — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
+   - Apply focused fixes.
+   - Verify each change in files.
+   - Commit per batch with clear message.
+   - Reply to each comment with concise factual status.
+   - Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
+     — the PR number is REQUIRED before `comments`; omitting it returns 404.
+     — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
 
 6. Keep docs in sync.
 - If fixes alter contracts, schema, workflow, or security behavior, update docs in same pass.
 
 7. Run quality and security gates.
-- Run lint/test checks for touched scope.
-- Perform security-focused review for sensitive files.
-- Address high-severity issues before push.
-- For Terraform files: classify any exposure of plaintext credentials or tokens in Terraform state as a high-severity security finding.
-- Block changes that introduce plaintext credential or token material into Terraform state, even if detect-secrets passes.
-- If touched changes include executable behavior and a unit test is reasonably possible, require that test in the same PR.
-- If such a test is missing, classify as a blocking finding.
-- Deferral is allowed only with explicit rationale and a linked follow-up issue.
-- Pure docs/process/license-only changes are exempt from this unit test requirement.
-- If lint or unit test targets are unavailable for touched scope, record this explicitly as a finding/testing gap (do not silently pass gates).
+  - Run lint/test checks for touched scope.
+  - Perform security-focused review for sensitive files.
+  - Address high-severity issues before push.
+  - For Python files: run bandit for static analysis (see .github/instructions/security.instructions.md).
+  - If touched changes include executable behavior and a unit test is reasonably possible, require that test in the same PR.
+  - If such a test is missing, classify as a blocking finding.
+  - Deferral is allowed only with explicit rationale and a linked follow-up issue.
+  - Pure docs/process/license-only changes are exempt from this unit test requirement.
+  - If lint or unit test targets are unavailable for touched scope, record this explicitly as a finding/testing gap (do not silently pass gates).
 
 8. Push and resolve threads.
 - Push once all batches and checks are complete.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -1,0 +1,78 @@
+---
+agent: agent
+description: Review all PR comments for this repository, validate each claim against project docs and changed files, fix valid issues, and post concise replies. Use MyVault's documentation and instruction files as authoritative sources.
+---
+
+Follow these steps exactly.
+
+1. Identify PR context.
+- Run gh pr view --json number,headRefName.
+- If there is no open PR for the current branch, stop and report that state.
+
+- List changed files from the PR.
+- Read each changed file in full.
+- Read relevant docs from this repository:
+  - docs/API.md
+  - docs/DEVELOPMENT.md
+  - docs/EXAMPLES.md
+  - docs/INSTALLATION.md
+  - docs/WORKFLOW.md
+- Read relevant instruction files from .github/instructions based on touched files:
+  - .github/instructions/pr.instructions.md
+  - .github/instructions/security.instructions.md
+  - .github/instructions/test.instructions.md
+
+3. Fetch all review comments.
+- Top-level PR comments: gh pr view <number> --comments
+- Inline comments: gh api --paginate repos/<owner>/<repo>/pulls/<number>/comments
+- Build comment-id to thread-id mapping using GraphQL reviewThreads pagination.
+
+4. Classify every comment.
+- Valid: the claim is accurate AND the fix prevents a realistic failure — a wrong result, a broken command, data loss, a security breach, or an operator being blocked from completing the procedure. The bar is "would a careful operator fail without this fix?"
+- Rejected: claim is factually wrong, contradicts current code or documented project decisions, OR is technically accurate but does not prevent a realistic operator failure (e.g. wording preferences, hypothetical edge cases in manually-executed runbooks, style inconsistencies, defensive improvements without a demonstrated failure path).
+- Ambiguous: cannot be resolved from available evidence; pause and ask user.
+
+For docs-only PRs, additionally reject:
+  - Observations about prose style or word choice where the current wording is unambiguous in context
+  - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
+  - Suggestions that duplicate information already present elsewhere in the same document
+
+5. Process valid comments in small batches.
+- Apply focused fixes.
+- Verify each change in files.
+- Commit per batch with clear message.
+- If detect-secrets updates .secrets.baseline metadata, stage it and retry commit.
+- Reply to each comment with concise factual status.
+- Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
+  — the PR number is REQUIRED before `comments`; omitting it returns 404.
+  — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
+
+6. Keep docs in sync.
+- If fixes alter contracts, schema, workflow, or security behavior, update docs in same pass.
+
+7. Run quality and security gates.
+- Run lint/test checks for touched scope.
+- Perform security-focused review for sensitive files.
+- Address high-severity issues before push.
+- For Terraform files: classify any exposure of plaintext credentials or tokens in Terraform state as a high-severity security finding.
+- Block changes that introduce plaintext credential or token material into Terraform state, even if detect-secrets passes.
+- If touched changes include executable behavior and a unit test is reasonably possible, require that test in the same PR.
+- If such a test is missing, classify as a blocking finding.
+- Deferral is allowed only with explicit rationale and a linked follow-up issue.
+- Pure docs/process/license-only changes are exempt from this unit test requirement.
+- If lint or unit test targets are unavailable for touched scope, record this explicitly as a finding/testing gap (do not silently pass gates).
+
+8. Push and resolve threads.
+- Push once all batches and checks are complete.
+- Resolve threads for fixed or rejected comments using thread IDs.
+
+9. Request re-review.
+- Tell user all threads are resolved.
+- If any commits were made during this review pass, run `gh pr edit <number> --add-reviewer @copilot` to trigger a new Copilot reviewer pass.
+- If no commits were made (all comments were rejected or already addressed), do not re-request — inform the user instead.
+
+Response style requirements:
+- Findings first, ordered by severity.
+- Include file references and concise rationale.
+- If no findings, state that explicitly and mention residual risks/testing gaps.
+- Always include a concise gate status line for touched scope: lint `passed|failed|not-available`; tests `passed|failed|not-available`.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -8,49 +8,49 @@ Follow these steps exactly.
 
 
 1. Identify PR context.
-   - Run gh pr view --json number,headRefName.
-   - If there is no open PR for the current branch, stop and report that state.
+  - Run gh pr view --json number,headRefName.
+  - If there is no open PR for the current branch, stop and report that state.
 
 2. Gather authoritative context for this project.
-   - List changed files from the PR.
-   - Read each changed file in full.
-   - Read relevant docs from this repository:
-     - docs/API.md
-     - docs/DEVELOPMENT.md
-     - docs/EXAMPLES.md
-     - docs/INSTALLATION.md
-     - docs/WORKFLOW.md
-   - Read relevant instruction files from .github/instructions based on touched files:
-     - .github/instructions/pr.instructions.md
-     - .github/instructions/security.instructions.md
-     - .github/instructions/test.instructions.md
-     - .github/instructions/docs.instructions.md (if any docs/** files are changed)
+  - List changed files from the PR.
+  - Read each changed file in full.
+  - Read relevant docs from this repository:
+    - docs/API.md
+    - docs/DEVELOPMENT.md
+    - docs/EXAMPLES.md
+    - docs/INSTALLATION.md
+    - docs/WORKFLOW.md
+  - Read relevant instruction files from .github/instructions based on touched files:
+    - .github/instructions/pr.instructions.md
+    - .github/instructions/security.instructions.md
+    - .github/instructions/test.instructions.md
+    - .github/instructions/docs.instructions.md (if any docs/** files are changed)
 
 3. Fetch all review comments.
-- Top-level PR comments: gh pr view <number> --comments
-- Inline comments: gh api --paginate repos/<owner>/<repo>/pulls/<number>/comments
-- Build comment-id to thread-id mapping using GraphQL reviewThreads pagination.
+  - Top-level PR comments: gh pr view <number> --comments
+  - Inline comments: gh api --paginate repos/<owner>/<repo>/pulls/<number>/comments
+  - Build comment-id to thread-id mapping using GraphQL reviewThreads pagination.
 
 4. Classify every comment.
-- Valid: the claim is accurate AND the fix prevents a realistic failure — a wrong result, a broken command, data loss, a security breach, or an operator being blocked from completing the procedure. The bar is "would a careful operator fail without this fix?"
-- Rejected: claim is factually wrong, contradicts current code or documented project decisions, OR is technically accurate but does not prevent a realistic operator failure (e.g. wording preferences, hypothetical edge cases in manually-executed runbooks, style inconsistencies, defensive improvements without a demonstrated failure path).
-- Ambiguous: cannot be resolved from available evidence; pause and ask user.
+  - Valid: the claim is accurate AND the fix prevents a realistic failure — a wrong result, a broken command, data loss, a security breach, or an operator being blocked from completing the procedure. The bar is "would a careful operator fail without this fix?"
+  - Rejected: claim is factually wrong, contradicts current code or documented project decisions, OR is technically accurate but does not prevent a realistic operator failure (e.g. wording preferences, hypothetical edge cases in manually-executed runbooks, style inconsistencies, defensive improvements without a demonstrated failure path).
+  - Ambiguous: cannot be resolved from available evidence; pause and ask user.
 
 For docs-only PRs, additionally reject:
   - Observations about prose style or word choice where the current wording is unambiguous in context
   - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
   - Suggestions that duplicate information already present elsewhere in the same document
 
-   - Apply focused fixes.
-   - Verify each change in files.
-   - Commit per batch with clear message.
-   - Reply to each comment with concise factual status.
-   - Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
-     — the PR number is REQUIRED before `comments`; omitting it returns 404.
-     — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
+  - Apply focused fixes.
+  - Verify each change in files.
+  - Commit per batch with clear message.
+  - Reply to each comment with concise factual status.
+  - Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
+    — the PR number is REQUIRED before `comments`; omitting it returns 404.
+    — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
 
 6. Keep docs in sync.
-- If fixes alter contracts, schema, workflow, or security behavior, update docs in same pass.
+  - If fixes alter contracts, schema, workflow, or security behavior, update docs in same pass.
 
 7. Run quality and security gates.
   - Run lint/test checks for touched scope.
@@ -64,16 +64,16 @@ For docs-only PRs, additionally reject:
   - If lint or unit test targets are unavailable for touched scope, record this explicitly as a finding/testing gap (do not silently pass gates).
 
 8. Push and resolve threads.
-- Push once all batches and checks are complete.
-- Resolve threads for fixed or rejected comments using thread IDs.
+  - Push once all batches and checks are complete.
+  - Resolve threads for fixed or rejected comments using thread IDs.
 
 9. Request re-review.
-- Tell user all threads are resolved.
-- If any commits were made during this review pass, run `gh pr edit <number> --add-reviewer @copilot` to trigger a new Copilot reviewer pass.
-- If no commits were made (all comments were rejected or already addressed), do not re-request — inform the user instead.
+  - Tell user all threads are resolved.
+  - If any commits were made during this review pass, run `gh pr edit <number> --add-reviewer @copilot` to trigger a new Copilot reviewer pass.
+  - If no commits were made (all comments were rejected or already addressed), do not re-request — inform the user instead.
 
 Response style requirements:
-- Findings first, ordered by severity.
-- Include file references and concise rationale.
-- If no findings, state that explicitly and mention residual risks/testing gaps.
-- Always include a concise gate status line for touched scope: lint `passed|failed|not-available`; tests `passed|failed|not-available`.
+  - Findings first, ordered by severity.
+  - Include file references and concise rationale.
+  - If no findings, state that explicitly and mention residual risks/testing gaps.
+  - Always include a concise gate status line for touched scope: lint `passed|failed|not-available`; tests `passed|failed|not-available`.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -36,18 +36,18 @@ Follow these steps exactly.
   - Rejected: claim is factually wrong, contradicts current code or documented project decisions, OR is technically accurate but does not prevent a realistic operator failure (e.g. wording preferences, hypothetical edge cases in manually-executed runbooks, style inconsistencies, defensive improvements without a demonstrated failure path).
   - Ambiguous: cannot be resolved from available evidence; pause and ask user.
 
-  For docs-only PRs, additionally reject:
-    - Observations about prose style or word choice where the current wording is unambiguous in context
-    - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
-    - Suggestions that duplicate information already present elsewhere in the same document
+5. For docs-only PRs, additionally reject:
+  - Observations about prose style or word choice where the current wording is unambiguous in context
+  - Defensive code improvements in scripts where the failure mode requires conditions not documented or plausible for this project
+  - Suggestions that duplicate information already present elsewhere in the same document
 
-    - Apply focused fixes.
-    - Verify each change in files.
-    - Commit per batch with clear message.
-    - Reply to each comment with concise factual status.
-    - Reply URL form: `repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies`
-      — the PR number is REQUIRED before `comments`; omitting it returns 404.
-      — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
+  - Apply focused fixes.
+  - Verify each change in files.
+  - Commit per batch with clear message.
+  - Reply to each comment with concise factual status.
+  - Reply URL form: `repos/{owner}/{repo}/pulls/comments/{comment_id}/replies`
+    — do not include the PR number in this endpoint; using `pulls/{pr_number}/comments/...` will 404.
+    — use `--input /tmp/<file>.json` (never `-f body=`); delete the temp file after success.
 
 6. Keep docs in sync.
   - If fixes alter contracts, schema, workflow, or security behavior, update docs in same pass.


### PR DESCRIPTION
## Summary
Adapt the review agent prompt to reference MyVault's actual documentation and instruction files.

## Changes
- .github/prompts/review.prompt.md: Updated to reference docs/API.md, docs/DEVELOPMENT.md, docs/EXAMPLES.md, docs/INSTALLATION.md, docs/WORKFLOW.md, and the three instruction files in .github/instructions. Removed references to non-existent files from other projects.

## Motivation
The previous version was copied from another project and referenced files that do not exist in MyVault. This update ensures the review agent uses the correct authoritative sources for this repository.

## Security considerations
None — prompt file only.

## Testing
N/A (prompt file, not executable code)

## Breaking changes
None
